### PR TITLE
v0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "dylink"
-version = "0.13.1"
+version = "0.14.0"
 edition = "2024"
 authors = ["Jonathan Thomason"]
 license = "MIT OR Apache-2.0"
@@ -11,7 +11,6 @@ keywords = ["ffi", "dlopen", "load", "shared", "lazy"]
 categories = ["api-bindings"]
 description = "Run-time dynamic linking loader utilities"
 repository = "https://github.com/Razordor/dylink.git"
-publish = true
 
 [workspace]
 members = ["dylink_macro"]
@@ -26,7 +25,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 all-features = true
 
 [features]
-derive = ["dep:dylink_macro"]
+macro = ["dep:dylink_macro"]
 
 [dev-dependencies]
-dylink = { path = ".", features = ["derive"] }
+dylink = { path = ".", features = ["macro"] }

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add this to your `Cargo.toml`
 
 ```toml
 [dependencies]
-dylink = "0.13"
+dylink = "0.14"
 ```
 
 ## Examples

--- a/dylink_macro/Cargo.toml
+++ b/dylink_macro/Cargo.toml
@@ -11,7 +11,6 @@ license = "MIT OR Apache-2.0"
 keywords = ["ffi", "macro", "macros", "attribute", "derive"]
 description = "Run-time dynamic linker loader attribute"
 repository = "https://github.com/Razordor/dylink.git"
-publish = true
 
 [lib]
 proc-macro = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ use std::{
 	path,
 };
 
-#[cfg(feature = "derive")]
+#[cfg(feature = "macro")]
 pub use dylink_macro::dylink;
 
 #[doc = include_str!("../README.md")]

--- a/tests/linux.rs
+++ b/tests/linux.rs
@@ -159,7 +159,9 @@ fn elf_span_64(data: &[u8]) -> Option<usize> {
 fn to_bytes_returns_full_image_size() {
 	let images = img::Images::now().expect("Should get images");
 	for weak in images {
-		let lib = weak.upgrade().expect("Should upgrade to strong reference");
+		let Some(lib) = weak.upgrade() else {
+			continue;
+		};
 		let image = lib.to_image().expect("Should get image from library");
 		let bytes = image.to_bytes().expect("Should get bytes from image");
 


### PR DESCRIPTION
Renamed feature derive to macro, because it's a misnomer. Removed publish = true.
Fixed a test that doesn't always pass.